### PR TITLE
Fix vegan emoji label in messages

### DIFF
--- a/src/messages/build_messages.ts
+++ b/src/messages/build_messages.ts
@@ -111,12 +111,12 @@ function emoji(category: string, notes: string[], sides: string[]): string {
         return ' 🍟🍟🍟';
     }
 
-    if (notes.includes('OLV')) {
-        return ' 🌱';
-    }
-
     if (notes.includes('vegan')) {
         return ' 🌱 (vegan)';
+    }
+
+    if (notes.includes('OLV')) {
+        return ' 🌱';
     }
 
     if (notes.includes('Fische')) {


### PR DESCRIPTION
This changes the order of the notes check in the message builders emoji function to check for the vegan tag first, as the STW labels vegan meals as both vegan and vegetarian.
This should fix vegan dishes being displayed only as vegetarian in the telegram message.