### PR TITLE
feat: canteen groups

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,35 @@
+{
+  "name": "TypeScript Node.js",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:22",
+  "features": {},
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "editor.formatOnPaste": true,
+        "editor.formatOnSave": true,
+        "editor.tabSize": 2,
+        "files.insertFinalNewline": true,
+        "todo-tree.highlights.useColourScheme": true
+      },
+      "extensions": [
+        // theme
+        "pkief.material-icon-theme",
+        "oderwat.indent-rainbow",
+        "usernamehw.errorlens",
+
+        // default extensions
+        "github.copilot",
+        "github.copilot-chat",
+        "gruntfuggly.todo-tree",
+        "eamodio.gitlens",
+        "streetsidesoftware.code-spell-checker",
+
+        // file support
+        "github.vscode-github-actions",
+        "bierner.markdown-emoji",
+        "ms-vscode.makefile-tools"
+      ]
+    }
+  }
+  // "postCreateCommand": "nvm install v22.12.0 && npm install"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fhaachenmensabot",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fhaachenmensabot",
-      "version": "1.0.2",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.9",
@@ -26,7 +26,7 @@
         "typescript": "^5.7.2"
       },
       "engines": {
-        "node": "^22.11.0"
+        "node": "^22.12.0"
       }
     },
     "node_modules/@grammyjs/types": {

--- a/src/messages/build_messages.ts
+++ b/src/messages/build_messages.ts
@@ -1,5 +1,5 @@
 import { todays_menus, tomorrows_menus } from "../parse/request_menus";
-import { all_canteens, greetings } from "../types/definitions"; 
+import { all_canteens, all_canteen_groups, greetings } from "../types/definitions"; 
 import { IMenu } from "../types/interfaces";
 import moment from "moment"
 import { TypeExpressionOperatorReturningBoolean } from "mongoose";
@@ -30,6 +30,22 @@ export function parseMessages() {
         final_messages.tomorrow_allergens[canteen.canteen_id] = escape_message(
             build_menu_message(tomorrows_menus[canteen.canteen_id], canteen.name, getDayTitle(), true)
         );
+    }
+    for(let canteen_group of all_canteen_groups) {
+        let today: string = "";
+        let today_allergens: string = "";
+        let tomorrow: string = "";
+        let tomorrow_allergens: string = "";
+        for (let canteen of canteen_group.canteens) {
+            today += final_messages.today[canteen.canteen_id];
+            today_allergens += final_messages.today_allergens[canteen.canteen_id];
+            tomorrow += final_messages.tomorrow[canteen.canteen_id];
+            tomorrow_allergens += final_messages.tomorrow_allergens[canteen.canteen_id];
+        }
+        final_messages.today[canteen_group.canteen_group_id] = today;
+        final_messages.today_allergens[canteen_group.canteen_group_id] = today_allergens;
+        final_messages.tomorrow[canteen_group.canteen_group_id] = tomorrow;
+        final_messages.tomorrow_allergens[canteen_group.canteen_group_id] = tomorrow_allergens;
     }
 }
 

--- a/src/types/definitions.ts
+++ b/src/types/definitions.ts
@@ -1,4 +1,4 @@
-import { ICanteen } from './interfaces';
+import { ICanteen, ICanteenGroup } from './interfaces';
 
 export const all_canteens: ICanteen[] = [
   {
@@ -61,6 +61,21 @@ export const all_canteens: ICanteen[] = [
     web_suffix: "goethestrasse-w.html",
     canteen_id: 10,
   },
+];
+
+// groups have to use a canteen_group_id >= 100
+// canteens have to use a canteen_id < 100
+export const max_canteen_id = 99;
+
+export const all_canteen_groups: ICanteenGroup[] = [
+  {
+    name: "Mensen Eupener Straße & Südpark",
+    canteen_group_id: 100,
+    canteens: [
+      all_canteens.find(c => c.identifier === "eups"),
+      all_canteens.find(c => c.identifier === "suedpark")
+    ]
+  }
 ];
 
 export const greetings: string[] = [

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -1,3 +1,9 @@
+export interface ICanteenGroup {
+    name: string;
+    canteen_group_id: number;
+    canteens: ICanteen[];
+}
+
 export interface ICanteen { 
     name: string; 
     identifier: string; 


### PR DESCRIPTION
this adds the function that canteen groups can be defined and selected by the user.

The implementation is not perfect: currently a group is defined as a "canteen" that has an id >= 100, this can be reworked, but I wanted to suggest this as a first draft.

also ive added a devcontainer for everyone who hasnt nodejs and typescript installed.

Attention: the feature is currently **not** tested with a dev bot.