### PR TITLE
Fair chances for all greetings

### DIFF
--- a/src/messages/build_messages.ts
+++ b/src/messages/build_messages.ts
@@ -39,7 +39,7 @@ export function escape_message(message: string): string {
 }
 
 export function random_greeting(): string {
-    const randomIndex = Math.floor(Math.random() * greetings.length);
+    const randomIndex = Math.round(Math.random() * greetings.length);
     return greetings[randomIndex];
 }
 


### PR DESCRIPTION
Use `Math.round()` instead of `Math.floor()` in `random_greeting()` to give the last entry a realistic chance of being selected.